### PR TITLE
Add query registration checks

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -2,6 +2,7 @@ import type { Component, ComponentMask } from './Component.js';
 
 import BitSet from 'bitset';
 import { Entity } from './Entity.js';
+import { assertCondition, ErrorMessages } from './Checks.js';
 
 export type QueryConfig = {
 	required: Component<any>[];
@@ -40,19 +41,29 @@ export class Query {
 		};
 	}
 
-	static generateQueryInfo(queryConfig: QueryConfig) {
-		let requiredMask = new BitSet();
-		let excludedMask = new BitSet();
-		queryConfig.required.forEach((c) => {
-			requiredMask = requiredMask.or(c.bitmask!);
-		});
-		queryConfig.excluded?.forEach((c) => {
-			excludedMask = excludedMask.or(c.bitmask!);
-		});
-		return {
-			requiredMask,
-			excludedMask,
-			queryId: `required:${requiredMask.toString()}|excluded:${excludedMask.toString()}`,
-		};
-	}
+        static generateQueryInfo(queryConfig: QueryConfig) {
+                let requiredMask = new BitSet();
+                let excludedMask = new BitSet();
+                queryConfig.required.forEach((c) => {
+                        assertCondition(
+                                c.bitmask !== null,
+                                ErrorMessages.ComponentNotRegistered,
+                                c,
+                        );
+                        requiredMask = requiredMask.or(c.bitmask!);
+                });
+                queryConfig.excluded?.forEach((c) => {
+                        assertCondition(
+                                c.bitmask !== null,
+                                ErrorMessages.ComponentNotRegistered,
+                                c,
+                        );
+                        excludedMask = excludedMask.or(c.bitmask!);
+                });
+                return {
+                        requiredMask,
+                        excludedMask,
+                        queryId: `required:${requiredMask.toString()}|excluded:${excludedMask.toString()}`,
+                };
+        }
 }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -449,22 +449,36 @@ describe('EliCS Integration Tests', () => {
 			expect(query.entities).toContain(entity);
 		});
 
-		test('Registering the same query multiple times', () => {
-			const queryConfig = {
-				required: [PositionComponent],
-			};
+                test('Registering the same query multiple times', () => {
+                        const queryConfig = {
+                                required: [PositionComponent],
+                        };
 
-			world.registerQuery(queryConfig);
-			const query1 = world.queryManager.registerQuery(queryConfig);
-			const query2 = world.queryManager.registerQuery(queryConfig);
+                        world.registerQuery(queryConfig);
+                        const query1 = world.queryManager.registerQuery(queryConfig);
+                        const query2 = world.queryManager.registerQuery(queryConfig);
 
-			expect(query1).toBe(query2);
-		});
+                        expect(query1).toBe(query2);
+                });
 
-		test('Query results from unregistered query', () => {
-			const world = new World({ checksOn: false });
-			world.registerComponent(PositionComponent);
-			const entity = world.createEntity();
+                test('Registering query with unregistered component throws error', () => {
+                        const UnregisteredComponent = createComponent({
+                                value: { type: Types.Int16, default: 0 },
+                        });
+
+                        const queryConfig = {
+                                required: [UnregisteredComponent],
+                        };
+
+                        expect(() => {
+                                world.queryManager.registerQuery(queryConfig);
+                        }).toThrow();
+                });
+
+                test('Query results from unregistered query', () => {
+                        const world = new World({ checksOn: false });
+                        world.registerComponent(PositionComponent);
+                        const entity = world.createEntity();
 			entity.addComponent(PositionComponent);
 
 			expect(


### PR DESCRIPTION
## Summary
- validate query components are registered before reading bitmask
- test query registration error case

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*