### PR TITLE
Improve benchmark reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,34 +20,28 @@ Thank you for being a part of the EliCS community!
 
 ## Benchmarks
 
-This repository includes a benchmark suite comparing EliCS to
-[ecsy](https://ecsyjs.github.io/ecsy/). Build the project and run the script:
+This repository includes a benchmark suite comparing EliCS to [ecsy](https://ecsyjs.github.io/ecsy/). Build the project and run the script:
 
 ```bash
 npm run build
 node benchmarks/ecs-benchmark.js
 ```
 
-The suite runs several scenarios derived from the
-[noctjs/ecs-benchmark](https://github.com/noctjs/ecs-benchmark) tests:
+The suite runs several scenarios derived from the [noctjs/ecs-benchmark](https://github.com/noctjs/ecs-benchmark) tests:
 
-- **Packed Iteration (5 queries)** – 1,000 entities each with components A–E.
-  Each query doubles the value stored in a single component.
-- **Simple Iteration** – 4,000 entities split across various component sets;
-  three systems swap component values.
-- **Fragmented Iteration** – 26 component types (A–Z) with 100 entities each
-  plus a Data component. Two queries double the Data and Z values.
-- **Entity Cycle** – 1,000 entities repeatedly spawn and then destroy entities
-  with a B component.
+- **Packed Iteration (5 queries)** – 1,000 entities each with components A–E. Each query doubles the value stored in a single component.
+- **Simple Iteration** – 4,000 entities split across various component sets; three systems swap component values.
+- **Fragmented Iteration** – 26 component types (A–Z) with 100 entities each plus a Data component. Two queries double the Data and Z values.
+- **Entity Cycle** – 1,000 entities repeatedly spawn and then destroy entities with a B component.
 - **Add / Remove** – 1,000 entities each add then remove a B component.
 
-Execution times for EliCS and ecsy are printed in milliseconds for easy
-comparison.
+Execution times for EliCS and ecsy are printed in milliseconds for easy comparison.
 
 ### Results
-
-- **Packed Iteration**: EliCS 8.27 ms | ecsy 10.07 ms
-- **Simple Iteration**: EliCS 9.08 ms | ecsy 10.75 ms
-- **Fragmented Iteration**: EliCS 6.49 ms | ecsy 3.35 ms
-- **Entity Cycle**: EliCS 35.43 ms | ecsy 125.55 ms
-- **Add / Remove**: EliCS 47.64 ms | ecsy 42.88 ms
+<!-- benchmark-start -->
+- **Packed Iteration**: **EliCS 15.99 ms** | ecsy 16.88 ms (5% better)
+- **Simple Iteration**: **EliCS 6.68 ms** | ecsy 23.85 ms (72% better)
+- **Fragmented Iteration**: **EliCS 6.49 ms** | ecsy 8.29 ms (22% better)
+- **Entity Cycle**: **EliCS 100.85 ms** | ecsy 318.70 ms (68% better)
+- **Add / Remove**: **EliCS 70.41 ms** | ecsy 108.78 ms (35% better)
+<!-- benchmark-end -->

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Execution times for EliCS and ecsy are printed in milliseconds for easy comparis
 
 ### Results
 <!-- benchmark-start -->
-- **Packed Iteration**: **EliCS 15.99 ms** | ecsy 16.88 ms (5% better)
-- **Simple Iteration**: **EliCS 6.68 ms** | ecsy 23.85 ms (72% better)
-- **Fragmented Iteration**: **EliCS 6.49 ms** | ecsy 8.29 ms (22% better)
-- **Entity Cycle**: **EliCS 100.85 ms** | ecsy 318.70 ms (68% better)
-- **Add / Remove**: **EliCS 70.41 ms** | ecsy 108.78 ms (35% better)
+- **Packed Iteration**: **EliCS 4.99 ms** | ecsy 9.01 ms (45% better)
+- **Simple Iteration**: **EliCS 3.87 ms** | ecsy 10.98 ms (65% better)
+- **Fragmented Iteration**: **EliCS 1.96 ms** | ecsy 3.39 ms (42% better)
+- **Entity Cycle**: **EliCS 36.29 ms** | ecsy 126.73 ms (71% better)
+- **Add / Remove**: **EliCS 30.11 ms** | ecsy 42.13 ms (29% better)
 <!-- benchmark-end -->


### PR DESCRIPTION
## Summary
- restore missing benchmark docs in README
- record benchmark results in bold with relative improvement
- inject results into README via markers
- remove noisy logs from benchmark script

## Testing
- `npm test`
- `npm run build`
- `npm run bench`
