### PR TITLE
Fix query registration to include existing entities

### DIFF
--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -481,13 +481,25 @@ describe('EliCS Integration Tests', () => {
                         const world = new World({ checksOn: false });
                         world.registerComponent(PositionComponent);
                         const entity = world.createEntity();
-			entity.addComponent(PositionComponent);
+                        entity.addComponent(PositionComponent);
 
-			expect(
-				new Query(PositionComponent.bitmask!, new BitSet(), '').entities,
-			).toEqual(new Set());
-		});
-	});
+                        expect(
+                                new Query(PositionComponent.bitmask!, new BitSet(), '').entities,
+                        ).toEqual(new Set());
+                });
+
+                test('Newly registered query finds existing entities', () => {
+                        const entity = world.createEntity();
+                        entity.addComponent(PositionComponent);
+
+                        const queryConfig = {
+                                required: [PositionComponent],
+                        };
+
+                        const query = world.queryManager.registerQuery(queryConfig);
+                        expect(query.entities).toContain(entity);
+                });
+        });
 
 	// System Tests
 	describe('System Tests', () => {


### PR DESCRIPTION
## Summary
- retain all entities in `QueryManager`
- include existing entities when registering a new query
- remove destroyed entities from tracker
- test that new queries capture entities created earlier

## Testing
- `npm test`