### PR TITLE
Add Entity reference component type

### DIFF
--- a/src/Component.ts
+++ b/src/Component.ts
@@ -69,7 +69,9 @@ export function assignInitialComponentData<
 		const length = TypedArrayMap[type].length;
 		const dataRef = component.data[key];
 		const input = initialData[key] ?? defaultValue;
-		if (length === 1 || type === Types.String || type === Types.Object) {
+		if (type === Types.Entity) {
+			dataRef[index] = input ? input.index : -1;
+		} else if (length === 1 || type === Types.String || type === Types.Object) {
 			dataRef[index] = input;
 		} else {
 			(dataRef as TypedArray).set(input, index * length);

--- a/src/EntityManager.ts
+++ b/src/EntityManager.ts
@@ -5,6 +5,7 @@ import type { QueryManager } from './QueryManager.js';
 export class EntityManager {
 	pool: Entity[] = [];
 	private entityIndex = 0;
+	private indexLookup: Map<number, Entity> = new Map();
 
 	constructor(
 		private queryManager: QueryManager,
@@ -25,10 +26,16 @@ export class EntityManager {
 			);
 		}
 
+		this.indexLookup.set(entity.index, entity);
+
 		return entity;
 	}
 
 	releaseEntityInstance(entity: Entity): void {
 		this.pool.push(entity);
+	}
+
+	getEntityByIndex(index: number): Entity | undefined {
+		return this.indexLookup.get(index);
 	}
 }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1,6 +1,7 @@
 export type DataType =
 	| 'Int8'
 	| 'Int16'
+	| 'Entity'
 	| 'Float32'
 	| 'Float64'
 	| 'Boolean'
@@ -13,6 +14,7 @@ export type DataType =
 export enum Types {
 	Int8 = 'Int8',
 	Int16 = 'Int16',
+	Entity = 'Entity',
 	Float32 = 'Float32',
 	Float64 = 'Float64',
 	Boolean = 'Boolean',
@@ -45,6 +47,7 @@ export const TypedArrayMap: {
 } = {
 	Int8: { arrayConstructor: Int8Array, length: 1 },
 	Int16: { arrayConstructor: Int16Array, length: 1 },
+	Entity: { arrayConstructor: Int16Array, length: 1 },
 	Float32: { arrayConstructor: Float32Array, length: 1 },
 	Float64: { arrayConstructor: Float64Array, length: 1 },
 	Boolean: { arrayConstructor: Uint8Array, length: 1 },
@@ -71,11 +74,14 @@ export type TypeValueToType<T extends DataType> = T extends
 					? [number, number, number]
 					: T extends 'Vec4'
 						? [number, number, number, number]
-						: any;
+						: T extends 'Entity'
+							? import('./Entity.js').Entity
+							: any;
 
 export type DataArrayToType<T extends DataType> = T extends
 	| 'Int8'
 	| 'Int16'
+	| 'Entity'
 	| 'Float32'
 	| 'Float64'
 	| 'Boolean'


### PR DESCRIPTION
## Summary
- allow components to hold entity references
- store entity indexes in component arrays
- look up entities on getValue
- convert entity objects to indexes on setValue
- keep index -> entity mapping in EntityManager
- test new Entity type

## Testing
- `npm run test`
- `npm run bench`