### PR TITLE
Improve benchmark stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,27 +41,27 @@ Execution times for EliCS and ecsy are printed in milliseconds for easy comparis
 <!-- benchmark-start -->
 
 **Packed Iteration**:
-  - `EliCS`: █████████ **4.24 ms**
-  - `Becsy`: ██████████████████ 8.38 ms
-  - `Ecsy `: ████████████████████ 8.99 ms
+  - `EliCS`: ██ **2.60 ms**
+  - `Becsy`: ████████████████████ 27.02 ms
+  - `Ecsy `: ██████ 7.92 ms
 
 **Simple Iteration**:
-  - `EliCS`: ██████ **3.95 ms**
-  - `Becsy`: ███████████ 6.94 ms
-  - `Ecsy `: ████████████████████ 11.87 ms
+  - `EliCS`: █ **3.25 ms**
+  - `Becsy`: ████████████████████ 66.47 ms
+  - `Ecsy `: ████ 10.61 ms
 
 **Fragmented Iteration**:
-  - `EliCS`: ██████████ **2.56 ms**
-  - `Becsy`: ████████████████████ 4.79 ms
-  - `Ecsy `: █████████████ 3.31 ms
+  - `EliCS`: ██ **1.35 ms**
+  - `Becsy`: ████████████████████ 14.00 ms
+  - `Ecsy `: █████ 2.92 ms
 
 **Entity Cycle**:
-  - `EliCS`: ██ **17.78 ms**
-  - `Becsy`: █████ 36.95 ms
-  - `Ecsy `: ████████████████████ 131.54 ms
+  - `EliCS`: ████ **21.84 ms**
+  - `Becsy`: ███████ 40.57 ms
+  - `Ecsy `: ████████████████████ 130.27 ms
 
 **Add / Remove**:
-  - `EliCS`: ████ **8.72 ms**
-  - `Becsy`: ████ 9.03 ms
-  - `Ecsy `: ████████████████████ 40.49 ms
+  - `EliCS`: ████ **7.77 ms**
+  - `Becsy`: █████ 8.85 ms
+  - `Ecsy `: ████████████████████ 40.97 ms
 <!-- benchmark-end -->

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The suite runs several scenarios derived from the [noctjs/ecs-benchmark](https:/
 - **Entity Cycle** – 1,000 entities repeatedly spawn and then destroy entities with a B component.
 - **Add / Remove** – 1,000 entities each add then remove a B component.
 
+Each scenario is executed 20 times and the average time is reported to reduce variance between runs.
+
 Execution times for EliCS and ecsy are printed in milliseconds for easy comparison, here's a snapshot of the results (**smaller is better**):
 
 <!-- benchmark-start -->

--- a/benchmarks/ecs-benchmark.js
+++ b/benchmarks/ecs-benchmark.js
@@ -90,9 +90,9 @@ function updateReadme(res) {
 		const bc = r.becsyTime.toFixed(2);
 		const fastest = Math.min(r.elicsTime, r.ecsyTime, r.becsyTime);
 		const slowest = Math.max(r.elicsTime, r.ecsyTime, r.becsyTime);
-		const elBar = '█'.repeat(Math.floor((r.elicsTime / slowest) * 20));
-		const ecBar = '█'.repeat(Math.floor((r.ecsyTime / slowest) * 20));
-		const bcBar = '█'.repeat(Math.floor((r.becsyTime / slowest) * 20));
+		const elBar = '█'.repeat(Math.ceil((r.elicsTime / slowest) * 20));
+		const ecBar = '█'.repeat(Math.ceil((r.ecsyTime / slowest) * 20));
+		const bcBar = '█'.repeat(Math.ceil((r.becsyTime / slowest) * 20));
 		const elBold = r.elicsTime === fastest ? `**${el} ms**` : `${el} ms`;
 		const ecBold = r.ecsyTime === fastest ? `**${ec} ms**` : `${ec} ms`;
 		const bcBold = r.becsyTime === fastest ? `**${bc} ms**` : `${bc} ms`;

--- a/benchmarks/ecs-benchmark.js
+++ b/benchmarks/ecs-benchmark.js
@@ -8,6 +8,8 @@ import * as becsy from './becsy.js';
 // Silence ecsy warnings in console
 console.warn = () => {};
 
+const RUNS = 20;
+
 const suites = [
 	[
 		'Packed Iteration',
@@ -36,9 +38,20 @@ const results = [];
 async function run() {
 	for (const [name, elicsFn, ecsyFn, becsyFn] of suites) {
 		try {
-			const elicsTime = elicsFn();
-			const ecsyTime = ecsyFn();
-			const becsyTime = await becsyFn();
+			let elicsSum = 0;
+			let ecsySum = 0;
+			let becsySum = 0;
+
+			for (let i = 0; i < RUNS; i++) {
+				elicsSum += elicsFn();
+				ecsySum += ecsyFn();
+				becsySum += await becsyFn();
+			}
+
+			const elicsTime = elicsSum / RUNS;
+			const ecsyTime = ecsySum / RUNS;
+			const becsyTime = becsySum / RUNS;
+
 			results.push({ name, elicsTime, ecsyTime, becsyTime });
 
 			console.log(`${name}:`);

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -22,30 +22,30 @@ export class Query {
 		public queryId: string,
 	) {}
 
-        matches(entity: Entity): boolean {
-                const hasRequired = entity.bitmask.contains(this.requiredMask);
-                const hasExcluded = entity.bitmask.intersects(this.excludedMask);
+	matches(entity: Entity): boolean {
+		const hasRequired = entity.bitmask.contains(this.requiredMask);
+		const hasExcluded = entity.bitmask.intersects(this.excludedMask);
 
-                return hasRequired && !hasExcluded;
-        }
+		return hasRequired && !hasExcluded;
+	}
 
-        subscribe(
-                event: 'qualify' | 'disqualify',
-                callback: (entity: Entity) => void,
-        ): () => void {
-                this.subscribers[event].add(callback);
-                return () => {
-                        this.subscribers[event].delete(callback);
-                };
-        }
+	subscribe(
+		event: 'qualify' | 'disqualify',
+		callback: (entity: Entity) => void,
+	): () => void {
+		this.subscribers[event].add(callback);
+		return () => {
+			this.subscribers[event].delete(callback);
+		};
+	}
 
-        static generateQueryInfo(queryConfig: QueryConfig): {
-                requiredMask: BitSet;
-                excludedMask: BitSet;
-                queryId: string;
-        } {
-                let requiredMask = new BitSet();
-                let excludedMask = new BitSet();
+	static generateQueryInfo(queryConfig: QueryConfig): {
+		requiredMask: BitSet;
+		excludedMask: BitSet;
+		queryId: string;
+	} {
+		let requiredMask = new BitSet();
+		let excludedMask = new BitSet();
 		queryConfig.required.forEach((c) => {
 			assertCondition(
 				c.bitmask !== null,


### PR DESCRIPTION
## Summary
- cache component classes in ecsy.js and becsy.js so multiple runs don't exceed component limits
- benchmark each scenario 20 times and average results (already documented)

## Testing
- `npm test`
- `npm run bench`
