### PR TITLE
Fix entity cleanup for deferred updates

### DIFF
--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -60,6 +60,12 @@ export class QueryManager {
 
 	resetEntity(entity: Entity): void {
 		this.trackedEntities.delete(entity);
+		// remove pending updates for this entity
+		const idx = this.entitiesToUpdate.indexOf(entity);
+		if (idx !== -1) {
+			this.entitiesToUpdate.splice(idx, 1);
+		}
+		entity.dirty = false;
 		this.queries.forEach((query) => query.entities.delete(entity));
 	}
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -494,11 +494,11 @@ describe('EliCS Integration Tests', () => {
 			expect(qualifyCallback).toHaveBeenCalledTimes(1);
 		});
 
-		test('Deferred entity updates', () => {
-			const world = new World({
-				checksOn: true,
-				deferredEntityUpdates: true,
-			});
+                test('Deferred entity updates', () => {
+                        const world = new World({
+                                checksOn: true,
+                                deferredEntityUpdates: true,
+                        });
 
 			world.registerComponent(PositionComponent);
 			world.registerComponent(VelocityComponent);
@@ -516,11 +516,36 @@ describe('EliCS Integration Tests', () => {
 			// query should not contain the entity before deferred update
 			expect(query.entities).not.toContain(entity);
 
-			world.queryManager.deferredUpdate();
+                        world.queryManager.deferredUpdate();
 
-			// query should contain the entity after deferred update
-			expect(query.entities).toContain(entity);
-		});
+                        // query should contain the entity after deferred update
+                        expect(query.entities).toContain(entity);
+                });
+
+                test('Destroyed entity pending update is ignored', () => {
+                        const world = new World({
+                                checksOn: true,
+                                deferredEntityUpdates: true,
+                        });
+
+                        world.registerComponent(PositionComponent);
+
+                        const queryConfig = {
+                                required: [PositionComponent],
+                        };
+
+                        const query = world.queryManager.registerQuery(queryConfig);
+
+                        const entity = world.createEntity();
+                        entity.addComponent(PositionComponent);
+
+                        entity.destroy();
+
+                        world.queryManager.deferredUpdate();
+
+                        expect((world.queryManager as any).trackedEntities.has(entity)).toBe(false);
+                        expect(query.entities).not.toContain(entity);
+                });
 
 		test('Registering the same query multiple times', () => {
 			const queryConfig = {


### PR DESCRIPTION
## Summary
- fix query manager cleanup when entities are destroyed before deferred update
- add regression test

## Testing
- `npm run format`
- `npm run test`
- `npm run bench`
