### PR TITLE
Fix entity reference overflow

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -28,6 +28,7 @@ export enum Types {
 export type TypedArray =
 	| Int8Array
 	| Int16Array
+	| Int32Array
 	| Float32Array
 	| Float64Array
 	| Uint8Array;
@@ -35,6 +36,7 @@ export type TypedArray =
 export type TypedArrayConstructor =
 	| Int8ArrayConstructor
 	| Int16ArrayConstructor
+	| Int32ArrayConstructor
 	| Float32ArrayConstructor
 	| Float64ArrayConstructor
 	| Uint8ArrayConstructor;
@@ -47,7 +49,7 @@ export const TypedArrayMap: {
 } = {
 	Int8: { arrayConstructor: Int8Array, length: 1 },
 	Int16: { arrayConstructor: Int16Array, length: 1 },
-	Entity: { arrayConstructor: Int16Array, length: 1 },
+	Entity: { arrayConstructor: Int32Array, length: 1 },
 	Float32: { arrayConstructor: Float32Array, length: 1 },
 	Float64: { arrayConstructor: Float64Array, length: 1 },
 	Boolean: { arrayConstructor: Uint8Array, length: 1 },

--- a/tests/entity_index_overflow.test.ts
+++ b/tests/entity_index_overflow.test.ts
@@ -1,0 +1,22 @@
+import { World } from '../src/World';
+import { createComponent } from '../src/Component';
+import { Types } from '../src/Types';
+
+describe('Entity index overflow', () => {
+	test('entity references work beyond Int16 range', () => {
+		const world = new World({ entityCapacity: 33000 });
+		const RefComp = createComponent({
+			ref: { type: Types.Entity, default: null as any },
+		});
+		world.registerComponent(RefComp);
+
+		// create a bunch of entities to exceed 32767 index
+		let last: any = null;
+		for (let i = 0; i < 33000; i++) {
+			last = world.createEntity();
+		}
+
+		last.addComponent(RefComp, { ref: last });
+		expect(last.getValue(RefComp, 'ref')).toBe(last);
+	});
+});


### PR DESCRIPTION
## Summary
- avoid index overflow in Components that store Entities
- test that entity references work beyond 32K indices

## Testing
- `npm run test`
- `npm run bench`
- `npm run format`
