### PR TITLE
Fix entity lookup cleanup

### DIFF
--- a/src/EntityManager.ts
+++ b/src/EntityManager.ts
@@ -32,6 +32,7 @@ export class EntityManager {
 	}
 
 	releaseEntityInstance(entity: Entity): void {
+		this.indexLookup.delete(entity.index);
 		this.pool.push(entity);
 	}
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -182,13 +182,23 @@ describe('EliCS Integration Tests', () => {
 			expect(newEntity.active).toBe(true);
 		});
 
-		test('Modifying destroyed entity throws error', () => {
-			const entity = world.createEntity();
-			entity.destroy();
+                test('Modifying destroyed entity throws error', () => {
+                        const entity = world.createEntity();
+                        entity.destroy();
 
-			expect(() => entity.addComponent(PositionComponent)).toThrow();
-		});
-	});
+                        expect(() => entity.addComponent(PositionComponent)).toThrow();
+                });
+
+                test('Entity index lookup updates on destroy', () => {
+                        const entity = world.createEntity();
+                        const index = entity.index;
+                        entity.destroy();
+
+                        const newEntity = world.createEntity();
+                        expect(newEntity.index).toBe(index);
+                        expect(world.entityManager.getEntityByIndex(index)).toBe(newEntity);
+                });
+        });
 
 	// Component Tests
 	describe('Component Tests', () => {


### PR DESCRIPTION
## Summary
- remove entity index from lookup when releasing entity
- ensure lookup map updates after destroying entities

## Testing
- `npm run test`
- `npm run bench`
- `npm run format`
