### PR TITLE
Improve entity destroy performance

### DIFF
--- a/benchmarks/elics.js
+++ b/benchmarks/elics.js
@@ -200,9 +200,9 @@ export function entityCycle() {
 			for (const _ of this.queries.as.entities) {
 				world.createEntity().addComponent(B);
 			}
-			for (const e of Array.from(this.queries.bs.entities)) {
-				e.destroy();
-			}
+                        for (const e of this.queries.bs.entities) {
+                                e.destroy();
+                        }
 		}
 	}
 

--- a/src/Entity.ts
+++ b/src/Entity.ts
@@ -154,12 +154,14 @@ export class Entity {
 		assertCondition(this.active, ErrorMessages.ModifyDestroyedEntity, this);
 		this.entityManager.releaseEntityInstance(this);
 		this.active = false;
-		const bitArray = this.bitmask.toArray();
-		for (const typeId of bitArray) {
-			const component = this.componentManager.getComponentByTypeId(typeId)!;
-			component.onDetach(component.data, this.index);
+		const bits = this.bitmask.bits;
+		for (let i = 0; i < 32; i++) {
+			if (bits & (1 << i)) {
+				const c = this.componentManager.getComponentByTypeId(i)!;
+				c.onDetach(c.data, this.index);
+			}
 		}
-		this.bitmask = new BitSet();
+		this.bitmask.bits = 0;
 		this.vectorViews.clear();
 		this.queryManager.resetEntity(this);
 	}


### PR DESCRIPTION
## Summary
- optimize Entity.destroy to avoid creating new BitSet and iterating using an array
- simplify entityCycle benchmark to iterate query set directly

## Testing
- `npm run build`
- `npm run test`
- `npm run format`
