### PR TITLE
Remove deferred entity update option

### DIFF
--- a/docs/architecture/world.md
+++ b/docs/architecture/world.md
@@ -11,7 +11,7 @@ The **World** class is the central hub of the EliCS ECS architecture. It orchest
 - **Component Registration**: Registers components with unique type IDs and BitSet masks, and initializes optimized storage using typed arrays.
 - **Entity Management**: Efficiently creates, pools, and recycles entities to minimize memory overhead.
 - **System Integration**: Registers systems with customizable configuration and execution priority, automatically wiring up system queries.
-- **Query Handling**: Uses BitSet masks for fast entity filtering and supports deferred updates to batch processing.
+- **Query Handling**: Uses BitSet masks for fast entity filtering.
 - **Global State Access**: Provides a shared `globals` object for cross-system communication and configuration.
 
 ## Implementation Overview
@@ -20,7 +20,7 @@ Under the hood, the **World** class initializes and connects three core managers
 
 - **ComponentManager**: Handles registration and storage of component data with performance in mind by leveraging typed arrays for cache-friendly access.
 - **EntityManager**: Uses an efficient pooling mechanism to create and recycle entities, reducing garbage collection overhead.
-- **QueryManager**: Maintains entity queries using BitSet masks for rapid matching and supports deferred entity updates, which are processed after each system update to optimize bulk modifications.
+- **QueryManager**: Maintains entity queries using BitSet masks for rapid matching.
 
 Systems are sorted based on priority during registration, ensuring that lower-priority systems are executed first. This design, along with the use of BitSet operations, contributes to a highly performant ECS implementation ideal for performance-critical applications.
 
@@ -77,13 +77,11 @@ An interface that defines the configuration options for the **World** class.
 interface WorldOptions {
         entityCapacity: number;
         checksOn: boolean;
-        deferredEntityUpdates: boolean;
 }
 ```
 
 - `entityCapacity` (`number`): The maximum number of entities the world can manage (default is 1000).
 - `checksOn` (`boolean`): Enables runtime validations for debugging purposes (default is true). It's recommended to disable checks in production for better performance.
-- `deferredEntityUpdates` (`boolean`): When `true`, entity changes are batched and processed after all systems update (default is false).
 
 ### World.constructor
 
@@ -178,7 +176,7 @@ getSystems(): System[];
 
 ### World.update
 
-Processes the ECS loop by updating each active system and processing any deferred entity updates.
+Processes the ECS loop by updating each active system.
 
 ```ts
 update(delta: number, time: number): void;

--- a/src/Entity.ts
+++ b/src/Entity.ts
@@ -25,7 +25,6 @@ export type VectorKeys<C extends Component<any>> = {
 export class Entity {
 	public bitmask: ComponentMask = new BitSet();
 	public active = true;
-	public dirty = false;
 	private vectorViews: Map<Component<any>, Map<string, TypedArray>> = new Map();
 
 	constructor(

--- a/src/World.ts
+++ b/src/World.ts
@@ -17,7 +17,6 @@ import { QueryManager } from './QueryManager.js';
 export interface WorldOptions {
 	entityCapacity: number;
 	checksOn: boolean;
-	deferredEntityUpdates: boolean;
 }
 
 export interface SystemOptions<T extends DataType, S extends SystemSchema<T>> {
@@ -35,10 +34,9 @@ export class World {
 	constructor({
 		entityCapacity = 1000,
 		checksOn = true,
-		deferredEntityUpdates = false,
 	}: Partial<WorldOptions> = {}) {
 		this.componentManager = new ComponentManager(entityCapacity);
-		this.queryManager = new QueryManager(deferredEntityUpdates);
+		this.queryManager = new QueryManager();
 		this.entityManager = new EntityManager(
 			this.queryManager,
 			this.componentManager,
@@ -134,7 +132,6 @@ export class World {
 				system.update(delta, time);
 			}
 		});
-		this.queryManager.deferredUpdate();
 	}
 
 	getSystem<

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -504,58 +504,6 @@ describe('EliCS Integration Tests', () => {
 			expect(qualifyCallback).toHaveBeenCalledTimes(1);
 		});
 
-                test('Deferred entity updates', () => {
-                        const world = new World({
-                                checksOn: true,
-                                deferredEntityUpdates: true,
-                        });
-
-			world.registerComponent(PositionComponent);
-			world.registerComponent(VelocityComponent);
-
-			const queryConfig = {
-				required: [PositionComponent, VelocityComponent],
-			};
-
-			const query = world.queryManager.registerQuery(queryConfig);
-
-			const entity = world.createEntity();
-			entity.addComponent(PositionComponent);
-			entity.addComponent(VelocityComponent);
-
-			// query should not contain the entity before deferred update
-			expect(query.entities).not.toContain(entity);
-
-                        world.queryManager.deferredUpdate();
-
-                        // query should contain the entity after deferred update
-                        expect(query.entities).toContain(entity);
-                });
-
-                test('Destroyed entity pending update is ignored', () => {
-                        const world = new World({
-                                checksOn: true,
-                                deferredEntityUpdates: true,
-                        });
-
-                        world.registerComponent(PositionComponent);
-
-                        const queryConfig = {
-                                required: [PositionComponent],
-                        };
-
-                        const query = world.queryManager.registerQuery(queryConfig);
-
-                        const entity = world.createEntity();
-                        entity.addComponent(PositionComponent);
-
-                        entity.destroy();
-
-                        world.queryManager.deferredUpdate();
-
-                        expect((world.queryManager as any).trackedEntities.has(entity)).toBe(false);
-                        expect(query.entities).not.toContain(entity);
-                });
 
 		test('Registering the same query multiple times', () => {
 			const queryConfig = {


### PR DESCRIPTION
## Summary
- drop `deferredEntityUpdates` option from `World`
- remove update deferral logic from `QueryManager`
- update docs to match new API
- delete obsolete tests

## Testing
- `npm run format`
- `npm run build`
- `npm run test`
