### PR TITLE
Improve query update performance

### DIFF
--- a/src/World.ts
+++ b/src/World.ts
@@ -38,7 +38,10 @@ export class World {
 		deferredEntityUpdates = false,
 	}: Partial<WorldOptions> = {}) {
 		this.componentManager = new ComponentManager(entityCapacity);
-		this.queryManager = new QueryManager(deferredEntityUpdates);
+		this.queryManager = new QueryManager(
+			deferredEntityUpdates,
+			this.componentManager,
+		);
 		this.entityManager = new EntityManager(
 			this.queryManager,
 			this.componentManager,


### PR DESCRIPTION
## Summary
- optimize `Entity.destroy` to loop only through active components
- map queries by component for targeted updates
- update world to supply component manager to query manager
- enhance `QueryManager.resetEntity` efficiency
- add integration tests for new query manager behavior

## Testing
- `npm run format`
- `npm run build`
- `npm run test`
