### PR TITLE
Trigger disqualify on entity destroy

### DIFF
--- a/__tests__/query.test.ts
+++ b/__tests__/query.test.ts
@@ -214,6 +214,22 @@ describe('Query Tests', () => {
 		expect(qualifyCallback).toHaveBeenCalledTimes(1);
 	});
 
+	test('Disqualify subscribers trigger on entity destroy', () => {
+		const query = world.queryManager.registerQuery({
+			required: [PositionComponent],
+		});
+		const disqualifyCallback = jest.fn();
+		query.subscribe('disqualify', disqualifyCallback);
+
+		const entity = world.createEntity();
+		entity.addComponent(PositionComponent);
+
+		// Destroying should trigger disqualify
+		entity.destroy();
+
+		expect(disqualifyCallback).toHaveBeenCalledTimes(1);
+	});
+
 	test('Registering the same query multiple times', () => {
 		const queryConfig = {
 			required: [PositionComponent],

--- a/src/query-manager.ts
+++ b/src/query-manager.ts
@@ -82,7 +82,13 @@ export class QueryManager {
 		// Fast path: remove from all queries if entity has no components
 		if (entity.bitmask.bits === 0) {
 			for (const query of this.queries.values()) {
-				query.entities.delete(entity);
+				if (query.entities.delete(entity)) {
+					if (query.subscribers.disqualify.size > 0) {
+						for (const callback of query.subscribers.disqualify) {
+							callback(entity);
+						}
+					}
+				}
 			}
 			return;
 		}
@@ -97,7 +103,13 @@ export class QueryManager {
 			if (queries) {
 				for (const query of queries) {
 					if (!processed.has(query)) {
-						query.entities.delete(entity);
+						if (query.entities.delete(entity)) {
+							if (query.subscribers.disqualify.size > 0) {
+								for (const callback of query.subscribers.disqualify) {
+									callback(entity);
+								}
+							}
+						}
 						processed.add(query);
 					}
 				}


### PR DESCRIPTION
## Summary
- fire `disqualify` callbacks when an entity is removed from a query in `resetEntity`
- add test to verify that destroying an entity triggers the `disqualify` subscriber

## Testing
- `npm test`